### PR TITLE
Add snake draft mode and roster display

### DIFF
--- a/Data/draftData.js
+++ b/Data/draftData.js
@@ -132,6 +132,7 @@ let draftState = {
     isPaused: false,
     currentPick: 1,
     currentDrafter: draftOrder[0],
+    draftDirection: 1, // 1 = forward, -1 = reverse (for snake)
     draftedPlayers: {}, // playerName: { owner, pickNumber, position }
     draftHistory: [], // array of picks in order
     completedRosters: {} // owner: array of players
@@ -147,6 +148,7 @@ function initializeDraft() {
         isPaused: false,
         currentPick: 1,
         currentDrafter: draftOrder[0],
+        draftDirection: 1,
         draftedPlayers: {},
         draftHistory: [],
         completedRosters: {}
@@ -175,6 +177,7 @@ function resetDraft() {
         isPaused: false,
         currentPick: 1,
         currentDrafter: draftOrder[0],
+        draftDirection: 1,
         draftedPlayers: {},
         draftHistory: [],
         completedRosters: {}
@@ -189,7 +192,12 @@ function loadDraftState() {
     const saved = localStorage.getItem('draftState');
     if (saved) {
         draftState = JSON.parse(saved);
-        
+
+        // Default direction if loading older state
+        if (!draftState.draftDirection) {
+            draftState.draftDirection = 1;
+        }
+
         // Update global rosters object with drafted players
         if (draftState.completedRosters) {
             Object.assign(rosters, draftState.completedRosters);
@@ -305,11 +313,20 @@ function draftPlayer(playerName, position) {
     
     // Advance to next pick
     draftState.currentPick++;
-    
+
     if (!isDraftComplete()) {
-        const currentDrafterIndex = draftOrder.indexOf(draftState.currentDrafter);
-        const nextDrafterIndex = (currentDrafterIndex + 1) % draftOrder.length;
-        draftState.currentDrafter = draftOrder[nextDrafterIndex];
+        const currentIndex = draftOrder.indexOf(draftState.currentDrafter);
+        let nextIndex = currentIndex + draftState.draftDirection;
+
+        if (nextIndex >= draftOrder.length) {
+            draftState.draftDirection = -1;
+            nextIndex = draftOrder.length - 1;
+        } else if (nextIndex < 0) {
+            draftState.draftDirection = 1;
+            nextIndex = 0;
+        }
+
+        draftState.currentDrafter = draftOrder[nextIndex];
     }
     
     saveDraftState();

--- a/draft.js
+++ b/draft.js
@@ -187,6 +187,13 @@ function createDraftInterfaceHTML() {
                         <!-- Will be populated by updatePositionCounts -->
                     </div>
                 </div>
+
+                <div class="drafted-players">
+                    <h3>Drafted Players:</h3>
+                    <div class="drafted-list roster-players" id="drafted-list">
+                        <!-- Will be populated by updateDraftedPlayersList -->
+                    </div>
+                </div>
                 
                 <div class="player-grid" id="player-grid">
                     <!-- Players will be populated here -->
@@ -249,6 +256,7 @@ function updateDraftInterface() {
     updatePositionCounts();
     updatePlayerGrid();
     updateRecentPicks();
+    updateDraftedPlayersList();
     
     // Check if draft is complete
     if (isDraftComplete()) {
@@ -329,6 +337,27 @@ function updateRecentPicks() {
             <span class="pick-player">${pick.player}</span>
             <span class="pick-position">${pick.position}</span>
             <span class="pick-team">${pick.team}</span>
+        </div>
+    `).join('');
+}
+
+// Show drafted players for current drafter
+function updateDraftedPlayersList() {
+    const container = document.getElementById('drafted-list');
+    if (!container) return;
+
+    const roster = draftState.completedRosters[draftState.currentDrafter] || [];
+
+    if (roster.length === 0) {
+        container.innerHTML = '<div class="no-picks">No players drafted yet</div>';
+        return;
+    }
+
+    container.innerHTML = roster.map(player => `
+        <div class="roster-player">
+            <span class="player-name">${player.name}</span>
+            <span class="player-pos">${player.position}</span>
+            <span class="player-team">${player.team}</span>
         </div>
     `).join('');
 }

--- a/styles.css
+++ b/styles.css
@@ -638,6 +638,18 @@ main {
     color: #721c24;
 }
 
+/* Drafted players list */
+.drafted-players {
+    padding: 1rem 1.5rem;
+    background: #f0f9ff;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.drafted-players h3 {
+    margin: 0 0 0.5rem 0;
+    color: #005778;
+}
+
 /* Team status */
 .position-status {
     display: flex;


### PR DESCRIPTION
## Summary
- switch draft order from linear to snake
- track draft direction in saved state
- show drafted players for each owner during draft
- style drafted players list

## Testing
- `python -m py_compile scripts/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6844eac79d34832bb0c7a4719cdcebd9